### PR TITLE
improve usability with required flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,24 +7,27 @@ use diss::{list_sessions, run};
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// list sessions
-    #[clap(short, long, value_parser)]
+    #[clap(short, long)]
     list: bool,
 
     // debug
-    #[clap(short, long, value_parser)]
+    #[clap(short, long)]
     debug: bool,
 
     // escape key
-    #[clap(short, long, value_parser)]
+    #[clap(short, long)]
     escape_key: Option<String>,
 
     // session name
-    #[clap(short, long, value_parser)]
+    #[clap(short, long)]
+    #[clap(required = true)]
     attach_session: Option<String>,
 
     // command
+    #[clap(required = true)]
     command: Vec<String>,
 }
+
 
 fn setup_logger() -> Result<(), fern::InitError> {
     fern::Dispatch::new()


### PR DESCRIPTION
at the moment running `diss` without having read the readme is a bit tricky, this change should improve usability by making it clearer to the user what flags that must specify.